### PR TITLE
Fix invalid class error

### DIFF
--- a/Hudl.StackDriver.PerfMon/App.config
+++ b/Hudl.StackDriver.PerfMon/App.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Hudl.StackDriver.PerfMon/Config/S3CounterConfigReader.cs
+++ b/Hudl.StackDriver.PerfMon/Config/S3CounterConfigReader.cs
@@ -39,7 +39,6 @@ namespace Hudl.StackDriver.PerfMon.Config
             string awsSecretKey)
             : this(s3Bucket, s3Key)
         {
-            _updateSeconds = updateSeconds;
             _awsAccessKey = awsAccessKey;
             _awsSecretKey = awsSecretKey;
             _updateTimer = InitializeTimer(updateSeconds);

--- a/Hudl.StackDriver.PerfMon/Config/S3CounterConfigReader.cs
+++ b/Hudl.StackDriver.PerfMon/Config/S3CounterConfigReader.cs
@@ -127,7 +127,8 @@ namespace Hudl.StackDriver.PerfMon.Config
                         var newConfig = new JsonSerializer<CountersConfig>().DeserializeFromString(fileContents);
                         if (newConfig != null && newConfig.Counters != null)
                         {
-                            ConfigUpdated(this, new CounterConfigEventArgs(newConfig.Counters));
+                            if (ConfigUpdated != null)
+                                ConfigUpdated(this, new CounterConfigEventArgs(newConfig.Counters));
                         }
                         DataLastModified = fileLastModified;
                     }

--- a/Hudl.StackDriver.PerfMon/LoggerFailureCallback.cs
+++ b/Hudl.StackDriver.PerfMon/LoggerFailureCallback.cs
@@ -5,7 +5,7 @@ namespace Hudl.StackDriver.PerfMon
 {
     public sealed class LoggerFailureCallback : CustomMetricsPoster.IFailureCallback
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(CustomMetricsPoster));
+        private static readonly ILog Logger = LogManager.GetLogger(typeof (CustomMetricsPoster));
 
         public void HandleMetricPostFailure(string metricName, HttpStatusCode statusCode, string body)
         {
@@ -15,7 +15,8 @@ namespace Hudl.StackDriver.PerfMon
             }
             else
             {
-                Logger.ErrorFormat("Send metrics batch failed. StatusCode={0}, Body={1}, MetricName={2}", statusCode, body, metricName);
+                Logger.ErrorFormat("Send metrics batch failed. StatusCode={0}, Body={1}, MetricName={2}", statusCode,
+                    body, metricName);
             }
         }
     }

--- a/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
+++ b/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
@@ -11,7 +11,6 @@ using Microsoft.Web.Administration;
 
 namespace Hudl.StackDriver.PerfMon
 {
-
     public class PerfMonReporter
     {
         private string ServerName { get; set; }
@@ -19,7 +18,7 @@ namespace Hudl.StackDriver.PerfMon
         private ICounterConfigReader ConfigReader { get; set; }
         private ManagementScope Scope { get; set; }
 
-        private static readonly ILog Log = LogManager.GetLogger(typeof(PerfMonReporter));
+        private static readonly ILog Log = LogManager.GetLogger(typeof (PerfMonReporter));
         private readonly CustomMetricsPoster _stackDriverPoster;
         private readonly string _instanceId;
         private readonly Timer _timer;
@@ -30,7 +29,8 @@ namespace Hudl.StackDriver.PerfMon
         private const int OneMinuteMilliseconds = 60000; //One minute is the minimum time between StackDriver metrics.
 #endif
 
-        public PerfMonReporter(IList<CounterConfig> counters, string instanceId, string stackDriverApiKey, ICounterConfigReader configReader)
+        public PerfMonReporter(IList<CounterConfig> counters, string instanceId, string stackDriverApiKey,
+            ICounterConfigReader configReader)
             : this(counters, instanceId, stackDriverApiKey, true)
         {
             ConfigReader = configReader;
@@ -46,7 +46,8 @@ namespace Hudl.StackDriver.PerfMon
         public void OnConfigurationUpdated(object sender, CounterConfigEventArgs e)
         {
             if (e == null || e.Counters == null) return;
-            Log.InfoFormat("Updated Counters. Previous={0} New={1}", Counters == null ? 0 : Counters.Count, e.Counters.Count);
+            Log.InfoFormat("Updated Counters. Previous={0} New={1}", Counters == null ? 0 : Counters.Count,
+                e.Counters.Count);
 
             Counters = e.Counters;
         }
@@ -63,7 +64,7 @@ namespace Hudl.StackDriver.PerfMon
 
             _instanceId = instanceId;
 
-            _timer = new Timer { Interval = OneMinuteMilliseconds };
+            _timer = new Timer {Interval = OneMinuteMilliseconds};
             _timer.Elapsed += GetMetrics;
         }
 
@@ -77,7 +78,6 @@ namespace Hudl.StackDriver.PerfMon
         {
             GetMetrics();
         }
-
 
 
         public async void GetMetrics()
@@ -157,9 +157,11 @@ namespace Hudl.StackDriver.PerfMon
             var instance = counter.Instance;
             var counterName = counter.Counter;
 
-            if (string.IsNullOrWhiteSpace(providerName) || string.IsNullOrWhiteSpace(categoryName) || string.IsNullOrWhiteSpace(counterName))
+            if (string.IsNullOrWhiteSpace(providerName) || string.IsNullOrWhiteSpace(categoryName) ||
+                string.IsNullOrWhiteSpace(counterName))
             {
-                Log.ErrorFormat("Invalid Counter. Provider={0}, Category={1}, Name={2}", providerName, categoryName, counterName);
+                Log.ErrorFormat("Invalid Counter. Provider={0}, Category={1}, Name={2}", providerName, categoryName,
+                    counterName);
                 return null;
             }
 
@@ -182,15 +184,15 @@ namespace Hudl.StackDriver.PerfMon
 
                 try
                 {
-                    Log.DebugFormat("Retrieved {0} results from '{1}'", results.Count(),queryString);
+                    Log.DebugFormat("Retrieved {0} results from '{1}'", results.Count(), queryString);
                 }
-                catch (ManagementException ex) 
+                catch (ManagementException ex)
                 {
                     Log.WarnFormat("Unable to read results of '{0}'", queryString, ex);
                     return null;
                 }
 
-                foreach(var result in results)
+                foreach (var result in results)
                 {
                     try
                     {
@@ -207,12 +209,16 @@ namespace Hudl.StackDriver.PerfMon
 
                         // Prefer in order of ApplicationName, ResultName, Instance or just use empty string.
                         var instanceName =
-                            !string.IsNullOrWhiteSpace(applicationPoolName) ? applicationPoolName
-                            : !string.IsNullOrWhiteSpace(resultName) ? resultName
-                            : !string.IsNullOrWhiteSpace(instance) ? instance
-                            : string.Empty;
+                            !string.IsNullOrWhiteSpace(applicationPoolName)
+                                ? applicationPoolName
+                                : !string.IsNullOrWhiteSpace(resultName)
+                                    ? resultName
+                                    : !string.IsNullOrWhiteSpace(instance)
+                                        ? instance
+                                        : string.Empty;
 
-                        Log.DebugFormat("{0}/{1}/{2} ({3}): {4}", ServerName, friendlyName, instanceName, applicationPoolName, value);
+                        Log.DebugFormat("{0}/{1}/{2} ({3}): {4}", ServerName, friendlyName, instanceName,
+                            applicationPoolName, value);
 
                         if (!string.IsNullOrWhiteSpace(instanceName))
                         {
@@ -222,7 +228,8 @@ namespace Hudl.StackDriver.PerfMon
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(string.Format("Exception while retrieving metric results. Query: {0}", queryString), ex);
+                        Log.Error(string.Format("Exception while retrieving metric results. Query: {0}", queryString),
+                            ex);
                     }
                 }
             }
@@ -239,7 +246,11 @@ namespace Hudl.StackDriver.PerfMon
             // Get the actual process name.
             var serverManager = new ServerManager();
             var applicationPoolCollection = serverManager.ApplicationPools;
-            foreach (var applicationPool in applicationPoolCollection.Where(applicationPool => applicationPool.WorkerProcesses.Any(workerProcess => workerProcess.ProcessId == processId)))
+            foreach (
+                var applicationPool in
+                    applicationPoolCollection.Where(
+                        applicationPool =>
+                            applicationPool.WorkerProcesses.Any(workerProcess => workerProcess.ProcessId == processId)))
             {
                 return applicationPool.Name;
             }

--- a/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
+++ b/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
@@ -45,9 +45,8 @@ namespace Hudl.StackDriver.PerfMon
 
         public void OnConfigurationUpdated(object sender, CounterConfigEventArgs e)
         {
-            if (e == null) return;
-
-            Log.InfoFormat("Updated Counters. Previous={0} New={1}", Counters == null ? 0 : Counters.Count, e.Counters == null ? 0 : e.Counters.Count);
+            if (e == null || e.Counters == null) return;
+            Log.InfoFormat("Updated Counters. Previous={0} New={1}", Counters == null ? 0 : Counters.Count, e.Counters.Count);
 
             Counters = e.Counters;
         }
@@ -179,8 +178,19 @@ namespace Hudl.StackDriver.PerfMon
             {
                 var queryResults = search.Get();
                 var applicationPoolName = "";
+                var results = queryResults.Cast<ManagementObject>();
 
-                foreach (var result in queryResults.Cast<ManagementObject>())
+                try
+                {
+                    Log.DebugFormat("Retrieved {0} results from '{1}'", results.Count(),queryString);
+                }
+                catch (ManagementException ex) 
+                {
+                    Log.WarnFormat("Unable to read results of '{0}'", queryString, ex);
+                    return null;
+                }
+
+                foreach(var result in results)
                 {
                     try
                     {

--- a/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
+++ b/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
@@ -33,10 +33,10 @@ namespace Hudl.StackDriver.PerfMon
             : this(counters, instanceId, stackDriverApiKey, true)
         {
             ConfigReader = configReader;
-            if (configReader != null)
+            if (ConfigReader != null)
             {
-                configReader.ConfigUpdated += OnConfigurationUpdated;
-                configReader.TriggerUpdate();
+                ConfigReader.ConfigUpdated += OnConfigurationUpdated;
+                ConfigReader.TriggerUpdate();
             }
 
             GetMetrics();
@@ -52,6 +52,7 @@ namespace Hudl.StackDriver.PerfMon
         }
 
         // init is just used to make the signature of this private constructor different.
+        // ReSharper disable once UnusedParameter.Local
         private PerfMonReporter(IList<CounterConfig> counters, string instanceId, string stackDriverApiKey, bool init)
         {
             var serverName = Environment.MachineName;
@@ -162,6 +163,7 @@ namespace Hudl.StackDriver.PerfMon
 
                 try
                 {
+                    // ReSharper disable once PossibleMultipleEnumeration
                     Log.DebugFormat("Retrieved {0} results from '{1}'", results.Count(), queryString);
                 }
                 catch (ManagementException ex)
@@ -170,6 +172,7 @@ namespace Hudl.StackDriver.PerfMon
                     return null;
                 }
 
+                // ReSharper disable once PossibleMultipleEnumeration
                 foreach (var result in results)
                 {
                     try

--- a/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
+++ b/Hudl.StackDriver.PerfMon/PerfMonReporter.cs
@@ -13,7 +13,6 @@ namespace Hudl.StackDriver.PerfMon
 {
     public class PerfMonReporter
     {
-        private string ServerName { get; set; }
         private IList<CounterConfig> Counters { get; set; }
         private ICounterConfigReader ConfigReader { get; set; }
         private ManagementScope Scope { get; set; }
@@ -217,7 +216,7 @@ namespace Hudl.StackDriver.PerfMon
                                         ? instance
                                         : string.Empty;
 
-                        Log.DebugFormat("{0}/{1}/{2} ({3}): {4}", ServerName, friendlyName, instanceName,
+                        Log.DebugFormat("{0}/{1} ({2}): {3}", friendlyName, instanceName,
                             applicationPoolName, value);
 
                         if (!string.IsNullOrWhiteSpace(instanceName))

--- a/Hudl.StackDriver.PerfMon/PerfMonService.cs
+++ b/Hudl.StackDriver.PerfMon/PerfMonService.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using Hudl.StackDriver.PerfMon.Config;
 using log4net;
 
@@ -8,14 +8,14 @@ namespace Hudl.StackDriver.PerfMon
 {
     internal class PerfMonService
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(PerfMonService));
+        private static readonly ILog Log = LogManager.GetLogger(typeof (PerfMonService));
         private PerfMonReporter _reporter;
 
         public void Start()
         {
             const string configFileName = "config.json";
 
-            var applicationFilePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            var applicationFilePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             if (applicationFilePath == null)
             {
                 Log.Error("Unable to get applications path");

--- a/Hudl.StackDriver.PerfMon/PerfmonAgentFactory.cs
+++ b/Hudl.StackDriver.PerfMon/PerfmonAgentFactory.cs
@@ -7,7 +7,7 @@ namespace Hudl.StackDriver.PerfMon
 {
     public class PerfMonAgentFactory
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(PerfMonAgentFactory));
+        private static readonly ILog Log = LogManager.GetLogger(typeof (PerfMonAgentFactory));
 
         public static PerfMonReporter CreateAgentWithConfiguration(CountersConfig config)
         {

--- a/Hudl.StackDriver.PerfMon/Program.cs
+++ b/Hudl.StackDriver.PerfMon/Program.cs
@@ -3,7 +3,7 @@ using Topshelf;
 
 namespace Hudl.StackDriver.PerfMon
 {
-    static class Program
+    internal static class Program
     {
         private static void Main()
         {
@@ -26,5 +26,3 @@ namespace Hudl.StackDriver.PerfMon
         }
     }
 }
-
-

--- a/Hudl.StackDriver.PerfMon/Properties/AssemblyInfo.cs
+++ b/Hudl.StackDriver.PerfMon/Properties/AssemblyInfo.cs
@@ -1,9 +1,11 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using log4net.Config;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
+
 [assembly: AssemblyTitle("Hudl.StackDriver.PerfMon")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -12,13 +14,15 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4netconfig.xml", Watch = true)]
+[assembly: XmlConfigurator(ConfigFile = "log4netconfig.xml", Watch = true)]
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
+
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
+
 [assembly: Guid("e51b3784-7581-405d-a442-6395caff43c2")]
 
 // Version information for an assembly consists of the following four values:
@@ -31,5 +35,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
+
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Hudl.StackDriver.PerfMon/log4netconfig.xml
+++ b/Hudl.StackDriver.PerfMon/log4netconfig.xml
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
+
 <log4net>
   <appender name="ColoredConsoleAppender" type="log4net.Appender.ColoredConsoleAppender">
     <mapping>
@@ -22,7 +23,8 @@
     <maxSizeRollBackups value="2" />
 
     <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="%utcdate Thread=%thread Level=%level Logger=&quot;%logger&quot; File=&quot;%file&quot; Line=%line Message=&quot;%message&quot;%newline" />
+      <conversionPattern
+        value="%utcdate Thread=%thread Level=%level Logger=&quot;%logger&quot; File=&quot;%file&quot; Line=%line Message=&quot;%message&quot;%newline" />
     </layout>
   </appender>
 

--- a/Hudl.StackDriver.PerfMon/packages.config
+++ b/Hudl.StackDriver.PerfMon/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="AWSSDK" version="2.3.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />


### PR DESCRIPTION
An 'Invalid Class' error will occur when a metric isn't retrievable using WMI. This fixes the error.

I've also ran ReSharper's code clean-up on this to to make it a bit more readable.